### PR TITLE
Fixes about NIST link

### DIFF
--- a/_includes/NISTPagesHeader.html
+++ b/_includes/NISTPagesHeader.html
@@ -21,7 +21,7 @@
 	</h1>
 	<div class="nist-links">
 	  <a class="nist-links-button" target="_blank" href="http://www.nist.gov">NIST Website</a>
-	  <a class="nist-links-button mobile-hide" target="_blank" href="http://www.nist.gov/public_affairs/nandyou.cfm">About NIST</a>
+	  <a class="nist-links-button mobile-hide" target="_blank" href="https://www.nist.gov/about-nist">About NIST</a>
 	  <a class="nist-links-button mobile-hide" target="_blank" href="https://github.com/usnistgov">usnistgov on GitHub</a>
 	</div>
 	


### PR DESCRIPTION
Looks like this about link was from before the Drupal migration.
