### PR TITLE
Print View updates

### DIFF
--- a/static/css/NISTStyle.css
+++ b/static/css/NISTStyle.css
@@ -198,6 +198,19 @@ td,th{
 		box-shadow:none !important
 	}
 
+	.nist-header {
+		display: none;
+	}
+
+	div.container {
+		padding-left:30px;
+		padding-right:30px;
+	}
+
+	.breaker{
+		page-break-before: always;
+	}
+
 	a,a:visited{
 		text-decoration:underline
 		color: purple;
@@ -246,7 +259,8 @@ td,th{
 	}
 
 	.navbar{
-		display:none
+		display:none;
+		width: 0px;
 	}
 
 	.table td,.table th{
@@ -6874,7 +6888,7 @@ table.GBInnerDataTable th{
 	text-align:center;
 	font-size:18px;
 	color:#555;
-	margin:15px 
+	margin:15px
 }
 
 #dropZone.hover{


### PR DESCRIPTION
-Remove nist-header from print view
-Set explicit padding (margins) on content container
-Introduce a style to produce page breaks in print view
-Explicitly set the width of .navbar elements to 0 in print view

These edits were introduced into the 800-63-3 repo and were recommended to be merged 'upward'.