### PR TITLE
Eliminate 301 Redirects in links from header and footer

### DIFF
--- a/_includes/NISTPagesFooter.html
+++ b/_includes/NISTPagesFooter.html
@@ -1,4 +1,4 @@
 <hr \>
 <section class="footer">
-<br><a target="_blank" href="http://www.nist.gov/public_affairs/privacy.cfm#privpolicy">Privacy Policy</a> | <a target="_blank" href="http://www.nist.gov/public_affairs/privacy.cfm#secnot">Security Notice</a> | <a href="http://www.nist.gov/public_affairs/privacy.cfm#accesstate">Accessibility Statement</a> | <a target="_blank" href="mailto:data@nist.gov?subject=Feedback%20on%20Web%20Site%20Template">Send feedback</a>
+<br><a target="_blank" href="https://www.nist.gov/privacy-policy#privpolicy">Privacy Policy</a> | <a target="_blank" href="https://www.nist.gov/privacy-policy#secnot">Security Notice</a> | <a href="https://www.nist.gov/privacy-policy#accesstate">Accessibility Statement</a> | <a target="_blank" href="mailto:data@nist.gov?subject=Feedback%20on%20Web%20Site%20Template">Send feedback</a>
 </section>

--- a/_includes/NISTPagesHeader.html
+++ b/_includes/NISTPagesHeader.html
@@ -17,10 +17,10 @@
 	<link rel="stylesheet" href="{{ site.baseurl }}/static/css/NISTPages.css">
 
 	<h1>
-	  <a class="nist-logo" target="_blank" href="http://www.nist.gov/" title="Go to nist.gov">National Institute of Standards and Technology</a>
+	  <a class="nist-logo" target="_blank" href="https://www.nist.gov/" title="Go to nist.gov">National Institute of Standards and Technology</a>
 	</h1>
 	<div class="nist-links">
-	  <a class="nist-links-button" target="_blank" href="http://www.nist.gov">NIST Website</a>
+	  <a class="nist-links-button" target="_blank" href="https://www.nist.gov">NIST Website</a>
 	  <a class="nist-links-button mobile-hide" target="_blank" href="http://www.nist.gov/public_affairs/nandyou.cfm">About NIST</a>
 	  <a class="nist-links-button mobile-hide" target="_blank" href="https://github.com/usnistgov">usnistgov on GitHub</a>
 	</div>


### PR DESCRIPTION
Corrects warnings detected by [W3C Link Checker](https://validator.w3.org/checklink) and small efficiency gain. The link checker also detected the redirect fixed by #3.